### PR TITLE
Added schema validation for submit order and createOrderPayload

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "homepage": "https://github.com/deversifi/dvf-client-js",
   "license": "MIT",
   "dependencies": {
+    "@hapi/joi": "^17.1.1",
     "@ledgerhq/hw-app-eth": "^5.12.2",
     "@ledgerhq/hw-transport-mocker": "^5.11.0",
     "@ledgerhq/hw-transport-node-hid": "^5.11.0",

--- a/src/api/submitOrder.js
+++ b/src/api/submitOrder.js
@@ -1,7 +1,34 @@
 const { post } = require('request-promise')
+const Joi = require('@hapi/joi')
+/*
+Keeping the schema visible and not in a seperate method
+for reference as required parameters can be checked by reading
+*/
+const schema = Joi.object({
+  symbol: Joi.string().required(), // trading symbol
+  amount: Joi.number().required(), // number or number string
+  price: Joi.number().required(), // number or number string
+  starkPrivateKey: Joi.string(), // required when using KeyStore wallet
+  ledgerPath: Joi.string(), // required when using Ledger wallet
+  validFor: Joi.number().allow(''), // validation time in hours
+  feeRate: Joi.number()
+    .allow('')
+    .raw(), // feeRate if known
+  dynamicFeeRate: Joi.number()
+    .allow('')
+    .raw(),
+  cid: Joi.string().allow(''),
+  gid: Joi.string().allow(''),
+  partnerId: Joi.string().allow(''),
+  ethAddress: Joi.string().pattern(/[\da-f]/i),
+  type: Joi.any().default('EXCHANGE LIMIT'),
+  protocol: Joi.any().default('stark')
+})
 
-// TODO: define a schema for data and validate it.
-module.exports = async (dvf, orderData) =>
-  post(dvf.config.api + '/v1/trading/w/submitOrder', {
-    json: await dvf.createOrderPayload(orderData)
+module.exports = async (dvf, orderData) => {
+  const { value } = schema.validate(orderData)
+
+  return post(dvf.config.api + '/v1/trading/w/submitOrder', {
+    json: await dvf.createOrderPayload(value)
   })
+}

--- a/src/api/submitOrder.test.js
+++ b/src/api/submitOrder.test.js
@@ -66,6 +66,8 @@ describe('dvf.submitOrder', () => {
       partnerId: 'P1', // partnerId
       dynamicFeeRate: '0'
     })
+
+    expect(payloadValidator).toBeCalled()
   })
 
   it('Submits sell order and receives response', async () => {
@@ -127,6 +129,7 @@ describe('dvf.submitOrder', () => {
       dynamicFeeRate: ''
       // ledgerPath: `21323'/0`
     })
+    expect(payloadValidator).toBeCalled()
   })
 
   it('Gives an error on missing symbol in request', async () => {
@@ -238,7 +241,7 @@ describe('dvf.submitOrder', () => {
     }
   })
 
-  it('Posts to submit order config API and gets error response', async () => {
+  it('Posts to submit order gets error response', async () => {
     const apiErrorResponse = {
       statusCode: 422,
       error: 'Unprocessable Entity',

--- a/src/lib/dvf/createOrderPayload.js
+++ b/src/lib/dvf/createOrderPayload.js
@@ -1,15 +1,38 @@
 const FP = require('lodash/fp')
+const Joi = require('@hapi/joi')
+/*
+repeating the schema here as this method can be called on its own  
+and keeping the schema visible and not in a seperate method 
+for reference as required parameters and tyoes can be checked 
+by reading the schema
+*/
+const schema = Joi.object({
+  symbol: Joi.string().required(), // trading symbol
+  amount: Joi.number().required(), // number or number string
+  price: Joi.number().required(), // number or number string
+  starkPrivateKey: Joi.string(), // required when using KeyStore wallet
+  ledgerPath: Joi.string(), // required when using Ledger wallet
+  validFor: Joi.number().allow(''), // validation time in hours
+  feeRate: Joi.number()
+    .allow('')
+    .prefs({ convert: false }), // feeRate if known
+  dynamicFeeRate: Joi.number()
+    .allow('')
+    .prefs({ convert: false }),
+  cid: Joi.string().allow(''),
+  gid: Joi.string().allow(''),
+  partnerId: Joi.string().allow(''),
+  ethAddress: Joi.string().pattern(/[\da-f]/i),
+  type: Joi.any().default('EXCHANGE LIMIT'),
+  protocol: Joi.any().default('stark')
+})
 
-// TODO: define a schema for orderData.
-// Default (like the type, protocol, feeRate below) can  go on that schema.
 module.exports = async (dvf, orderData) => {
-  // allow passing in ethAddress (useful for testing).
+  const { value } = schema.validate(orderData)
+
   const ethAddress = orderData.ethAddress || dvf.get('account')
 
   return {
-    type: 'EXCHANGE LIMIT',
-    protocol: 'stark',
-    feeRate: 0.0025,
     ...FP.pick(
       [
         'amount',
@@ -19,13 +42,15 @@ module.exports = async (dvf, orderData) => {
         'gid',
         'partnerId',
         'price',
-        'symbol'
+        'symbol',
+        'type',
+        'protocol'
       ],
-      orderData
+      value
     ),
     meta: {
       ethAddress,
-      ...(await dvf.createOrderMetaData(orderData))
+      ...(await dvf.createOrderMetaData(value))
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,46 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@hapi/address@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.0.1.tgz#267301ddf7bc453718377a6fb3832a2f04a721dd"
+  integrity sha512-0oEP5UiyV4f3d6cBL8F3Z5S7iWSX39Knnl0lY8i+6gfmmIBj44JCBNtcMgwyS+5v7j3VYavNay0NFHDS+UGQcw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@hapi/formula@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-2.0.0.tgz#edade0619ed58c8e4f164f233cda70211e787128"
+  integrity sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==
+
+"@hapi/hoek@^9.0.0":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.0.4.tgz#e80ad4e8e8d2adc6c77d985f698447e8628b6010"
+  integrity sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==
+
+"@hapi/joi@^17.1.1":
+  version "17.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-17.1.1.tgz#9cc8d7e2c2213d1e46708c6260184b447c661350"
+  integrity sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==
+  dependencies:
+    "@hapi/address" "^4.0.1"
+    "@hapi/formula" "^2.0.0"
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/pinpoint" "^2.0.0"
+    "@hapi/topo" "^5.0.0"
+
+"@hapi/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-2.0.0.tgz#805b40d4dbec04fc116a73089494e00f073de8df"
+  integrity sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"


### PR DESCRIPTION
Added schema validation for submitOrder and createOrderPayLoad.
This is partly to address concerns that bundling all parameters into an object will reduce usability as parameter names and types will not be self-evident.
The schema has been added to both submitOrder and createOrderPayload as these two methods can be called separately.